### PR TITLE
IOT-39: Generating passthrough keycodes with nexus python

### DIFF
--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -193,7 +193,7 @@ class BaseFullMessage(object):
         keycode = self.header + self.body
 
         # Passthrough keycodes do not contain a MAC
-        if hasattr(self, "mac"):
+        if self.mac is not None:
             keycode += self.mac
 
         if obscured or (obscured is not False and not self.is_factory):

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -404,6 +404,7 @@ class FactoryFullMessage(FullMessage):
 
         :param application_id: ID of device application processing this command
         :type application_id: :class:`PassthroughApplicationId`
+        :type passthrough_digits: :class:`string`
         :return: Message object of format PASSTHROUGH_COMMAND
         :rtype: :class:`FactoryFullMessage`
         """

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -22,11 +22,11 @@ class FullMessageType(enum.Enum):
     ADD_CREDIT = 0
     SET_CREDIT = 1
     WIPE_STATE = 2
-    RESERVED = 3
+    RESERVED_TYPE_ID_3 = 3
     FACTORY_ALLOW_TEST = 4
     FACTORY_OQC_TEST = 5
     FACTORY_DISPLAY_PAYG_ID = 6
-    RESERVED = 7
+    RESERVED_TYPE_ID_7 = 7
     PASSTHROUGH_COMMAND = 8
 
     @property

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -91,7 +91,7 @@ class BaseFullMessage(object):
         :param message_type: integer value for the message type
         :type message_type: :class:`FullMessageType`
         :param body: arbitrary digits of message body
-        :type body: :class:`bytes`
+        :type body: :class:`string`
         :param secret_key: secret hash key (requires 16 bytes, uses first 16)
         :type secret_key: `bytes`
         """
@@ -108,8 +108,8 @@ class BaseFullMessage(object):
         self.body = body  # shorter body for 'factory' messages
 
         if self.is_factory is True:
-            # assert len(body) == 0
-            self.body_int = 0
+            if self.body == "":
+                self.body_int = 0
             assert full_id == 0
             self.header = u"{0}".format(self.message_type.value)  # ignore full_id
 

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -75,7 +75,7 @@ class BaseFullMessage(object):
 
     Typically, you'll want to use one of the specific derived types instead.
 
-    :see: :class:`FactoryMessage`
+    :see: :class:`FactoryFullMessage`
     :see: :class:`FullMessage`
     """
 
@@ -107,7 +107,7 @@ class BaseFullMessage(object):
         self.body = body  # shorter body for 'factory' messages
 
         if self.is_factory is True:
-            #assert len(body) == 0
+            # assert len(body) == 0
             self.body_int = 0
             assert full_id == 0
             self.header = u"{0}".format(self.message_type.value)  # ignore full_id
@@ -191,9 +191,8 @@ class BaseFullMessage(object):
         keycode = self.header + self.body
 
         # Passthrough keycodes do not contain a MAC
-        if hasattr(self, 'mac'):
+        if hasattr(self, "mac"):
             keycode += self.mac
-
 
         if obscured or (obscured is not False and not self.is_factory):
             keycode = self.obscure(keycode)
@@ -354,7 +353,7 @@ class FactoryFullMessage(FullMessage):
         Message contains no body.
 
         :return: Message object of format FACTORY_ALLOW_TEST
-        :rtype: :class:`FactoryMessage`
+        :rtype: :class:`FactoryFullMessage`
         """
         return cls(message_type=FullMessageType.FACTORY_ALLOW_TEST, body="")
 
@@ -367,7 +366,7 @@ class FactoryFullMessage(FullMessage):
         Message contains no body.
 
         :return: Message object of format FACTORY_OQC_TEST
-        :rtype: :class:`FactoryMessage`
+        :rtype: :class:`FactoryFullMessage`
         """
         return cls(message_type=FullMessageType.FACTORY_OQC_TEST, body="")
 
@@ -381,13 +380,13 @@ class FactoryFullMessage(FullMessage):
         Message contians no body.
 
         :return: Message object of format FACTORY_DISPLAY_PAYG_ID_TEST
-        :rtype: :class:`FactoryMessage`
+        :rtype: :class:`FactoryFullMessage`
         """
         return cls(message_type=FullMessageType.FACTORY_DISPLAY_PAYG_ID, body="")
 
     @classmethod
     def passthrough_command(cls, application_id, passthrough_digits):
-        # type: (PassthroughApplicationId, str)-> FactoryMessage
+        # type: (PassthroughApplicationId, str)-> FactoryFullMessage
         """Send a keycode which contains application-specific data, and
         will not be parsed by the embedded keycode library. Passthrough
         commands do not trigger any UI feedback (keycode accepted/etc) from the
@@ -407,12 +406,12 @@ class FactoryFullMessage(FullMessage):
         :param application_id: ID of device application processing this command
         :type id_: :class:`PassthroughCommandSubtypeIds`
         :return: Message object of format PASSTHROUGH_COMMAND
-        :rtype: :class:`FactoryMessage`
+        :rtype: :class:`FactoryFullMessage`
         """
         if not isinstance(application_id, PassthroughApplicationId):
             raise TypeError("Passthrough command requires an application ID.")
 
-        body = "{:d}{}".format(application_id.value, passthrough_digits)
+        body = u"{:d}{}".format(application_id.value, passthrough_digits)
 
         if len(body) == 13:
             # Once we append the Passthrough type ID, we'll be at 14 digits.
@@ -420,4 +419,4 @@ class FactoryFullMessage(FullMessage):
             # tokens.
             raise ValueError("Passthrough command cannot be 13 total digits.")
 
-        return cls(message_type=FullMessageType.PASSTHROUGH_COMMAND, body=body)    
+        return cls(message_type=FullMessageType.PASSTHROUGH_COMMAND, body=body)

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -26,7 +26,7 @@ class FullMessageType(enum.Enum):
     FACTORY_ALLOW_TEST = 4
     FACTORY_OQC_TEST = 5
     FACTORY_DISPLAY_PAYG_ID = 6
-    RESERVE = 7
+    RESERVED = 7
     PASSTHROUGH_COMMAND = 8
 
     @property
@@ -91,7 +91,7 @@ class BaseFullMessage(object):
         :param message_type: integer value for the message type
         :type message_type: :class:`FullMessageType`
         :param body: arbitrary digits of message body
-        :type body: :class:`string`
+        :type body: str
         :param secret_key: secret hash key (requires 16 bytes, uses first 16)
         :type secret_key: `bytes`
         """
@@ -404,6 +404,7 @@ class FactoryFullMessage(FullMessage):
 
         :param application_id: ID of device application processing this command
         :type application_id: :class:`PassthroughApplicationId`
+        :param passthrough_digits: Digits that will be built into a message
         :type passthrough_digits: :class:`string`
         :return: Message object of format PASSTHROUGH_COMMAND
         :rtype: :class:`FactoryFullMessage`
@@ -414,7 +415,7 @@ class FactoryFullMessage(FullMessage):
         body = u"{:d}{}".format(application_id.value, passthrough_digits)
 
         if len(body) == 13:
-            # Once we append the Passthrough type ID, we'll be at 14 digits.
+            # Once we append the message header, we'll be at 14 digits.
             # Firmware uses 14-digits to unambiguously identify 'activation'
             # tokens.
             raise ValueError("Passthrough body cannot be 13 total digits.")

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -277,6 +277,7 @@ class TestFactoryFullMessage(TestCase):
             protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
             passthrough_digits="9238284782879",
         )
+        self.assertEqual(msg.PassthroughApplicationId,0)
         self.assertEqual(
             msg.header,
             u"{:01d}".format(protocol.FullMessageType.PASSTHROUGH_COMMAND.value),

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -290,21 +290,15 @@ class TestFactoryFullMessage(TestCase):
     def test_passthrough_command__body_length_error__value_error_expected(self):
         self.assertRaises(
             ValueError,
-            self.assertRaises(
-                ValueError,
-                protocol.FactoryFullMessage.passthrough_command,
-                protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
-                passthrough_digits="238284782879",
-            ),
+            protocol.FactoryFullMessage.passthrough_command,
+            protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
+            passthrough_digits="238284782879",
         )
 
     def test_passthrough_command__application_id_error__type_error_expected(self):
         self.assertRaises(
             TypeError,
-            self.assertRaises(
-                TypeError,
-                protocol.FactoryFullMessage.passthrough_command,
-                2,
-                passthrough_digits="09238284782879",
-            ),
+            protocol.FactoryFullMessage.passthrough_command,
+            2,
+            passthrough_digits="09238284782879",
         )

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -269,3 +269,18 @@ class TestFactoryFullMessage(TestCase):
         )
         self.assertEqual(msg.body, "")
         self.assertEqual("*634 776 5#", keycode)
+
+
+    def test_passthrough_command__channel_command__expected(self):
+        # Send an ASP/Channel command via passthrough in keycodev1 protocol
+        msg = protocol.FactoryFullMessage.passthrough_command(
+            protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
+            passthrough_digits='9238284782879'
+        )
+        self.assertEqual(
+            msg.header,
+            "{:01d}".format(
+                protocol.FullMessageType.PASSTHROUGH_COMMAND.value))
+        # passthrough "Application ID" = 0
+        self.assertEqual(msg.body, '09238284782879')
+        self.assertEqual(msg.to_keycode(), "*709 238 284 782 879#")

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -278,6 +278,7 @@ class TestFactoryFullMessage(TestCase):
             passthrough_digits="9238284782879",
         )
         self.assertEqual(msg.PassthroughApplicationId,0)
+        self.assertEqual(len(msg.body), 13)
         self.assertEqual(
             msg.header,
             u"{:01d}".format(protocol.FullMessageType.PASSTHROUGH_COMMAND.value),

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -244,7 +244,7 @@ class TestFactoryFullMessage(TestCase):
 
         self.assertEqual(
             msg.header,
-            "{:01d}".format(protocol.FullMessageType.FACTORY_ALLOW_TEST.value),
+            u"{:01d}".format(protocol.FullMessageType.FACTORY_ALLOW_TEST.value),
         )
         self.assertEqual(msg.body, "")
         self.assertEqual("*406 498 3#", keycode)
@@ -254,7 +254,8 @@ class TestFactoryFullMessage(TestCase):
         keycode = msg.to_keycode()
 
         self.assertEqual(
-            msg.header, "{:01d}".format(protocol.FullMessageType.FACTORY_OQC_TEST.value)
+            msg.header,
+            u"{:01d}".format(protocol.FullMessageType.FACTORY_OQC_TEST.value),
         )
         self.assertEqual(msg.body, "")
         self.assertEqual("*577 043 3#", keycode)
@@ -265,22 +266,21 @@ class TestFactoryFullMessage(TestCase):
 
         self.assertEqual(
             msg.header,
-            "{:01d}".format(protocol.FullMessageType.FACTORY_DISPLAY_PAYG_ID.value),
+            u"{:01d}".format(protocol.FullMessageType.FACTORY_DISPLAY_PAYG_ID.value),
         )
         self.assertEqual(msg.body, "")
         self.assertEqual("*634 776 5#", keycode)
-
 
     def test_passthrough_command__channel_command__expected(self):
         # Send an ASP/Channel command via passthrough in keycodev1 protocol
         msg = protocol.FactoryFullMessage.passthrough_command(
             protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
-            passthrough_digits='9238284782879'
+            passthrough_digits="9238284782879",
         )
         self.assertEqual(
             msg.header,
-            "{:01d}".format(
-                protocol.FullMessageType.PASSTHROUGH_COMMAND.value))
+            u"{:01d}".format(protocol.FullMessageType.PASSTHROUGH_COMMAND.value),
+        )
         # passthrough "Application ID" = 0
-        self.assertEqual(msg.body, '09238284782879')
+        self.assertEqual(msg.body, "09238284782879")
         self.assertEqual(msg.to_keycode(), "*709 238 284 782 879#")

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -297,3 +297,14 @@ class TestFactoryFullMessage(TestCase):
                 passthrough_digits="238284782879",
             ),
         )
+
+    def test_passthrough_command__application_id_error__type_error_expected(self):
+        self.assertRaises(
+            TypeError,
+            self.assertRaises(
+                TypeError,
+                protocol.FactoryFullMessage.passthrough_command,
+                2,
+                passthrough_digits="09238284782879",
+            ),
+        )

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -286,3 +286,14 @@ class TestFactoryFullMessage(TestCase):
         # passthrough "Application ID" = 0
         self.assertEqual(msg.body, "09238284782879")
         self.assertEqual(msg.to_keycode(), "*809 238 284 782 879#")
+
+    def test_passthrough_command__body_length_error__value_error_expected(self):
+        self.assertRaises(
+            ValueError,
+            self.assertRaises(
+                ValueError,
+                protocol.FactoryFullMessage.passthrough_command,
+                protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
+                passthrough_digits="238284782879",
+            ),
+        )

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -272,7 +272,7 @@ class TestFactoryFullMessage(TestCase):
         self.assertEqual("*634 776 5#", keycode)
 
     def test_passthrough_command__channel_command__expected(self):
-        # Send an ASP/Channel command via passthrough in keycodev1 protocol
+        # Send an arbitrary PAYG_UART_PASSTHROUGH message
         msg = protocol.FactoryFullMessage.passthrough_command(
             protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
             passthrough_digits="9238284782879",

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -277,12 +277,12 @@ class TestFactoryFullMessage(TestCase):
             protocol.PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH,
             passthrough_digits="9238284782879",
         )
-        self.assertEqual(msg.PassthroughApplicationId,0)
-        self.assertEqual(len(msg.body), 13)
+        self.assertEqual(msg.full_id, 0)
+        self.assertEqual(len(msg.body), 14)
         self.assertEqual(
             msg.header,
             u"{:01d}".format(protocol.FullMessageType.PASSTHROUGH_COMMAND.value),
         )
         # passthrough "Application ID" = 0
         self.assertEqual(msg.body, "09238284782879")
-        self.assertEqual(msg.to_keycode(), "*709 238 284 782 879#")
+        self.assertEqual(msg.to_keycode(), "*809 238 284 782 879#")


### PR DESCRIPTION
## Proposed changes

Add passthrough keycode to UART generation functionality to nexus-python. This will allow us to generate any passthrough keycode. Passthrough-to-UART keycodes have the following structure: *80<body># (full-keycode protocol type 8, passthrough keycode subtype 0). So a passthrough keycode carrying the body 0123456 should be *800123456#

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have added unit tests with >= 90% coverage for all files modified or added by these changes
- [x ] I have designed my tests to prove that my fix is effective or that my feature works as described
- [x ] I have added docstrings to all new functions describing their purpose, parameters, and return value
- [x ] I have updated or added supplemental documentation (if appropriate)
- [ x] Any dependent changes have been merged and published in downstream modules

## Further comments

Documentation for this change can be found [here](https://github.com/angaza/payg-backend/pull/10643/files?short_path=c6699fc#diff-c6699fc9687c3d45a109e7cdd7a4a84bbbf8a3b16187aa5cdc4e446475acdfdf) (Step 1 of Proposal)

Link to any supplemental information here.

### Reviewers:

This will be filled by the people who review this particular Pull Request.

### Attribution

This PR template derived from:
https://github.com/skcript/PR-Template

Original template is:

Copyright (c) 2017 Skcript

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.
