### PR TITLE
IOT-159 Passthrough keycode generation

### DIFF
--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -432,7 +432,7 @@ class FactoryFullMessage(FullMessage):
         :param secret_key: secret key used to generate UART security key
         :type secret_key: byte
         """
-        mac = compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key)
-        return FactoryFullMessage.passthrough_command(
-            PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH, mac
+        numeric_body_and_mac = compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key)
+        return cls.passthrough_command(
+            PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH, numeric_body_and_mac
         )

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -426,5 +426,11 @@ class FactoryFullMessage(FullMessage):
 
     @classmethod
     def passthrough_uart_keycode_numeric_body_and_mac(cls, secret_key):
+        """Use a given secret key to generate a passthrough keycode
+        :param secret_key: secret key used to generate UART security key
+        :type secret_key: byte
+        """
         mac = compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key)
-        return FactoryFullMessage.passthrough_command(PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH, mac)
+        return FactoryFullMessage.passthrough_command(
+            PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH, mac
+        )

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -4,8 +4,10 @@ import math
 import bitstring
 import siphash
 
+from nexus_keycode.protocols.passthrough_uart import (
+    compute_passthrough_uart_keycode_numeric_body_and_mac,
+)
 from nexus_keycode.protocols.utils import pseudorandom_bits
-from passthrough_uart import compute_passthrough_uart_keycode_numeric_body_and_mac
 
 NEXUS_MODULE_VERSION_STRING = "1.0.0"
 NEXUS_INTEGRITY_CHECK_FIXED_00_KEY = b"\x00" * 16

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -5,8 +5,10 @@ import bitstring
 import siphash
 
 from nexus_keycode.protocols.utils import pseudorandom_bits
+from passthrough_uart import compute_passthrough_uart_keycode_numeric_body_and_mac
 
 NEXUS_MODULE_VERSION_STRING = "1.0.0"
+NEXUS_INTEGRITY_CHECK_FIXED_00_KEY = b"\x00" * 16
 
 
 @enum.unique
@@ -421,3 +423,8 @@ class FactoryFullMessage(FullMessage):
             raise ValueError("Passthrough body cannot be 13 total digits.")
 
         return cls(message_type=FullMessageType.PASSTHROUGH_COMMAND, body=body)
+
+    @classmethod
+    def passthrough_uart_keycode_numeric_body_and_mac(cls, secret_key):
+        mac = compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key)
+        return FactoryFullMessage.passthrough_command(PassthroughApplicationId.TO_PAYG_UART_PASSTHROUGH, mac)

--- a/nexus_keycode/protocols/passthrough_uart.py
+++ b/nexus_keycode/protocols/passthrough_uart.py
@@ -1,4 +1,5 @@
 import siphash
+from nexus_keycode.protocols.utils import generate_mac
 
 NEXUS_INTEGRITY_CHECK_FIXED_00_KEY = b"\x00" * 16
 
@@ -24,3 +25,10 @@ def compute_uart_security_key(secret_key):
 
     # Return hashed halves as completed uart_security_key
     return hash_part_a + hash_part_b
+
+def compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key):
+    uart_security_key = compute_uart_security_key(secret_key)
+    mac = generate_mac('\x00',uart_security_key)
+    # Include the 0 we used to calculate MAC in the passthrough keycode
+    mac = '0'+ mac
+    return mac

--- a/nexus_keycode/protocols/passthrough_uart.py
+++ b/nexus_keycode/protocols/passthrough_uart.py
@@ -34,7 +34,7 @@ def compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key):
     :type secret_key: byte
     """
     uart_security_key = compute_uart_security_key(secret_key)
-    mac = generate_mac("\x00", uart_security_key)
+    mac = generate_mac(b"\x00", uart_security_key)
     # Include the 0 we used to calculate MAC
     mac = "0" + mac
     return mac

--- a/nexus_keycode/protocols/passthrough_uart.py
+++ b/nexus_keycode/protocols/passthrough_uart.py
@@ -1,4 +1,5 @@
 import siphash
+
 from nexus_keycode.protocols.utils import generate_mac
 
 NEXUS_INTEGRITY_CHECK_FIXED_00_KEY = b"\x00" * 16
@@ -26,9 +27,14 @@ def compute_uart_security_key(secret_key):
     # Return hashed halves as completed uart_security_key
     return hash_part_a + hash_part_b
 
+
 def compute_passthrough_uart_keycode_numeric_body_and_mac(secret_key):
+    """Use a given secret key to generate the body/mac of a keycode
+    :param secret_key: secret key used to generate body/mac of a keycode
+    :type secret_key: byte
+    """
     uart_security_key = compute_uart_security_key(secret_key)
-    mac = generate_mac('\x00',uart_security_key)
-    # Include the 0 we used to calculate MAC in the passthrough keycode
-    mac = '0'+ mac
+    mac = generate_mac("\x00", uart_security_key)
+    # Include the 0 we used to calculate MAC
+    mac = "0" + mac
     return mac

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -302,3 +302,8 @@ class TestFactoryFullMessage(TestCase):
             2,
             passthrough_digits="09238284782879",
         )
+
+    def test_passthrough_uart_keycode_numeric_body_and_mac__standard_input__ok(self):
+        input_bytes = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+        passthrough_keycode = protocol.FactoryFullMessage.passthrough_uart_keycode_numeric_body_and_mac(input_bytes)
+        self.assertEqual(passthrough_keycode.to_keycode(), u"*800 875 838#")


### PR DESCRIPTION


## Proposed changes
The ability to generate passthrough keycodes along with a unit test to cover new functionality. (referencing this https://github.com/angaza/payg-backend/pull/10643 doc)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have added unit tests with >= 90% coverage for all files modified or added by these changes
- [ ] I have designed my tests to prove that my fix is effective or that my feature works as described
- [ ] I have added docstrings to all new functions describing their purpose, parameters, and return value
- [ ] I have updated or added supplemental documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This change is the next step in implementing passthrough keycode generation for nexus API

Link to any supplemental information here.

### Reviewers:



### Attribution

This PR template derived from:
https://github.com/skcript/PR-Template

Original template is:

Copyright (c) 2017 Skcript

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.
