### PR TITLE
fix: OQC code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ message = FullMessage.wipe_state(
 Enabled/Disabled Test
 ```python
 message = FactoryFullMessage.oqc_test().to_keycode()
-# outputs *577 043 3#
+# outputs *500 060 694 509#
 ```
 
 Factory Test

--- a/nexus_keycode/protocols/full.py
+++ b/nexus_keycode/protocols/full.py
@@ -117,6 +117,8 @@ class BaseFullMessage(object):
         if self.is_factory is True:
             if self.body == "":
                 self.body_int = 0
+            else:
+                self.body_int = int(self.body)
             assert full_id == 0
             self.header = u"{0}".format(self.message_type.value)  # ignore full_id
 
@@ -352,17 +354,21 @@ class FactoryFullMessage(FullMessage):
         return cls(message_type=FullMessageType.FACTORY_ALLOW_TEST, body="")
 
     @classmethod
-    def oqc_test(cls):
-        """Provide 1 hour of credit (additive) up to 10 times per device.
+    def oqc_test(cls, num_min=60):
+        # type: (int)->FactoryFullMessage
+        """Provide :num_min of credit (additive) up to 10 times per device.
 
         Allows for factory and warehouse ongoing testing before sale.
 
-        Message contains no body.
-
+        :param num_min: int of minutes of credit to add to device.
         :return: Message object of format FACTORY_OQC_TEST
         :rtype: :class:`FactoryFullMessage`
         """
-        return cls(message_type=FullMessageType.FACTORY_OQC_TEST, body="")
+        if not isinstance(num_min, int):
+            raise TypeError("Expected num_min to be an instance of int but actual type was: {}.".format(type(num_min)))
+        if num_min < 1 or 99 < num_min:
+            raise ValueError("num_min must be between 1 and 99 but was: {}.".format(num_min))
+        return cls(message_type=FullMessageType.FACTORY_OQC_TEST, body="000{:02d}".format(num_min))
 
     @classmethod
     def display_payg_id(cls):

--- a/nexus_keycode/test/protocols/test_full.py
+++ b/nexus_keycode/test/protocols/test_full.py
@@ -257,8 +257,8 @@ class TestFactoryFullMessage(TestCase):
             msg.header,
             u"{:01d}".format(protocol.FullMessageType.FACTORY_OQC_TEST.value),
         )
-        self.assertEqual(msg.body, "")
-        self.assertEqual("*577 043 3#", keycode)
+        self.assertEqual(msg.body, "00060")
+        self.assertEqual("*500 060 694 509#", keycode)
 
     def test_display_payg_id__verify_output__ok(self):
         msg = protocol.FactoryFullMessage.display_payg_id()

--- a/nexus_keycode/test/protocols/test_readme.py
+++ b/nexus_keycode/test/protocols/test_readme.py
@@ -41,7 +41,7 @@ class TestREADME(TestCase):
 
     def test_oqc_test__full__ok(self):
         message = FactoryFullMessage.oqc_test()
-        self.assertEqual("*577 043 3#", message.to_keycode())
+        self.assertEqual("*500 060 694 509#", message.to_keycode())
 
     def test_factory_test__full__ok(self):
         message = FactoryFullMessage.allow_test()


### PR DESCRIPTION
## Contribution Guideline Acceptance

- [x] I have read and understand the [Individual Contributors License Agreement](CONTRIBUTING.md).
- [x] I accept the [Individual Contributors License Agreement](CONTRIBUTING.md) on the entire contents of this pull request.

## Proposed changes

Update OQC code generation to sync with the decoder's spec: https://github.com/angaza/nexus-embedded/blob/3f3c5a797caff13db1258e4ed3846cc6a8268e05/nexus/src/nexus_keycode_pro.c#L1236-L1249

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have added unit tests with >= 90% coverage for all files modified or added by these changes
- [x] I have designed my tests to prove that my fix is effective or that my feature works as described
- [x] I have added docstrings to all new functions describing their purpose, parameters, and return value
- [x] I have updated or added supplemental documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

TODOs:
- [ ] Check that the same bug isn't in nexus-java
- [x] Test on desktop sample program:

```
Initializing product interfaces...
Please enter the path to the NV file (if it does not exist, then it will be created).
test.nv
Done with product interfaces
Initializing Nexus library...
Done
Credit remaining: 86400 seconds



--------

--Menu--

--------

1. Enter Nexus Keycode
2. Display Nexus Channel Status
3. Enter processing loop (hide menu)
4. Simulate GET to Battery Resource
5. Update Battery Resource (Low Battery Threshold)'
Selection: 1
Please input a Full keycode (20 digits maximum): *500 060 694 509#
        Input (length=17): *500 060 694 509#


passing along key=[*500060694509#] len=14
        Keycode is valid.
Credit remaining: 89957 seconds



--------

--Menu--

--------

1. Enter Nexus Keycode
2. Display Nexus Channel Status
3. Enter processing loop (hide menu)
4. Simulate GET to Battery Resource
5. Update Battery Resource (Low Battery Threshold)'
Selection: 1
Please input a Full keycode (20 digits maximum): *500 060 694 509#
        Input (length=17): *500 060 694 509#


passing along key=[*500060694509#] len=14
        Keycode is valid.
Credit remaining: 93545 seconds
```

### Reviewers:

This will be filled by the people who review this particular Pull Request.

### Attribution

This PR template derived from:
https://github.com/skcript/PR-Template

Original template is:

Copyright (c) 2017 Skcript

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.
