### PR TITLE
Nexus Keycode/Channel integration test plan keycode generator scripts

### DIFF
--- a/nexus_keycode/test/tools/test_generate_full_keycode.py
+++ b/nexus_keycode/test/tools/test_generate_full_keycode.py
@@ -1,14 +1,21 @@
 from unittest import TestCase
 
-import bitstring
-from nexus_keycode.tools.generate_full_keycode import create_full_credit_message
 import nexus_keycode.protocols.full as protocol
+from nexus_keycode.tools.generate_full_keycode import (
+    create_full_channel_message,
+    create_full_credit_message,
+)
 
 
 class TestCreateFullCreditMessage(TestCase):
     def test_invalid_msg_type__raises(self):
         self.assertRaises(
-            ValueError, create_full_credit_message, 15, "INVALID_TYPE", b"\x12\xab" * 8, hours=168
+            ValueError,
+            create_full_credit_message,
+            15,
+            "INVALID_TYPE",
+            b"\x12\xab" * 8,
+            hours=168,
         )
 
     def test_valid_add_credit__returns_expected(self):
@@ -29,3 +36,48 @@ class TestCreateFullCreditMessage(TestCase):
         # 'unlock' is a special case of set credit for full protocol
         self.assertEqual(protocol.FullMessageType.SET_CREDIT, msg.message_type)
         self.assertEqual(u"*425 687 269 124 32#", msg.to_keycode())
+
+
+class TestCreateFullChannelMessage(TestCase):
+    def test_invalid_msg_type__raises(self):
+        self.assertRaises(
+            ValueError,
+            create_full_channel_message,
+            "INVALID_TYPE",
+            b"\x12\xab" * 8,
+            15,
+            b"\xab\x12" * 8,
+            3,
+        )
+
+    def test_valid_unlink__returns_expected(self):
+        msg = create_full_channel_message("UNLINK", b"\x12\xab" * 8, 15)
+        self.assertEqual(protocol.FullMessageType.PASSTHROUGH_COMMAND, msg.message_type)
+        self.assertEqual(u"*815 310 472 88#", msg.to_keycode())
+
+    def test_valid_link__returns_expected(self):
+        msg = create_full_channel_message(
+            "LINK", b"\x12\xab" * 8, 15, b"\xab\x12" * 8, 3
+        )
+        self.assertEqual(protocol.FullMessageType.PASSTHROUGH_COMMAND, msg.message_type)
+        self.assertEqual(u"*819 501 596 413 845#", msg.to_keycode())
+
+    def test_invalid_link__no_accessory_key__raises(self):
+        self.assertRaises(
+            ValueError,
+            create_full_channel_message,
+            "LINK",
+            b"\x12\xab" * 8,
+            15,
+            accessory_command_count=3,
+        )
+
+    def test_invalid_link__no_accessory_count__raises(self):
+        self.assertRaises(
+            ValueError,
+            create_full_channel_message,
+            "LINK",
+            b"\x12\xab" * 8,
+            15,
+            b"\xab\x12" * 8,
+        )

--- a/nexus_keycode/tools/generate_full_keycode.py
+++ b/nexus_keycode/tools/generate_full_keycode.py
@@ -1,4 +1,4 @@
-# Small Nexus Keycode Protocol Credit Keycode Generator
+# Full Nexus Keycode Protocol Keycode Generator
 # Convenience script to generate keycodes 'on the fly' for testing/QA purposes.
 
 import argparse
@@ -54,11 +54,11 @@ if __name__ == "__main__":
         return decode_hex(secret_key)[0]
 
     argparser = argparse.ArgumentParser(
-        description="Generate credit keycodes for Nexus Keycode 'small' protocol.",
-        epilog="python generate_small_keycode.py -t ADD -i 0 -k abcdef0011223344556677889900ffee -d 30",
+        description="Generate credit keycodes for Nexus Keycode 'full' protocol.",
+        epilog="python generate_full_keycode.py -t ADD -i 0 -k abcdef0011223344556677889900ffee -hr 30",
     )
 
-    # Note: 'UNLOCK' is implemented as a special case of "ADD", but for the purposes of this tool they are considered separate 'types'.
+    # Note: 'UNLOCK' is implemented as a special case of "SET", but for the purposes of this tool they are considered separate 'types'.
     argparser.add_argument(
         "-t",
         "--message_type",

--- a/nexus_keycode/tools/generate_full_keycode.py
+++ b/nexus_keycode/tools/generate_full_keycode.py
@@ -23,7 +23,7 @@ def create_full_credit_message(msg_id, msg_type, secret_key, hours=None):
     if msg_type == "UNLOCK":
         return protocol.FullMessage.unlock(msg_id, secret_key)
 
-    if not hours:
+    if hours is None:
         raise ValueError(
             u"Expected non-null `hours` argument for message type {}".format(msg_type)
         )

--- a/nexus_keycode/tools/generate_full_keycode.py
+++ b/nexus_keycode/tools/generate_full_keycode.py
@@ -3,35 +3,85 @@
 
 import argparse
 import codecs
+
 import nexus_keycode.protocols.full as protocol
+from nexus_keycode.protocols.channel_origin_commands import ChannelOriginAction
 
-
-VALID_MESSAGE_TYPES = ["SET", "UNLOCK", "ADD"]
+VALID_NXK_MESSAGE_TYPES = ["SET", "UNLOCK", "ADD"]
+VALID_NXC_MESSAGE_TYPES = ["LINK", "UNLINK"]
 
 
 def create_full_credit_message(msg_id, msg_type, secret_key, hours=None):
 
-    if msg_type not in VALID_MESSAGE_TYPES:
+    if msg_type not in VALID_NXK_MESSAGE_TYPES:
         raise ValueError(
-            u"Invalid message type, supported values are {}".format(VALID_MESSAGE_TYPES)
+            u"Invalid message type, supported values are {}".format(
+                VALID_NXK_MESSAGE_TYPES
+            )
         )
 
-    if msg_type == "SET":
-        msg = protocol.FullMessage.set_credit(msg_id, hours, secret_key)
-    elif msg_type == "ADD":
-        msg = protocol.FullMessage.add_credit(msg_id, hours, secret_key)
+    if msg_type == "UNLOCK":
+        return protocol.FullMessage.unlock(msg_id, secret_key)
+
+    if not hours:
+        raise ValueError(
+            u"Expected non-null `hours` argument for message type {}".format(msg_type)
+        )
+
+    if msg_type == "ADD":
+        return protocol.FullMessage.add_credit(msg_id, hours, secret_key)
     else:
-        assert msg_type == "UNLOCK"
-        msg = protocol.FullMessage.unlock(msg_id, secret_key)
-    return msg
+        assert msg_type == "SET"
+        return protocol.FullMessage.set_credit(msg_id, hours, secret_key)
+
+
+def create_full_channel_message(
+    msg_type,
+    controller_sym_key,
+    controller_command_count,
+    accessory_sym_key=None,
+    accessory_command_count=None,
+):
+
+    if msg_type not in VALID_NXC_MESSAGE_TYPES:
+        raise ValueError(
+            u"Invalid message type, supported values are {}".format(
+                VALID_NXC_MESSAGE_TYPES
+            )
+        )
+
+    if msg_type == "UNLINK":
+        return protocol.FactoryFullMessage.passthrough_channel_origin_command(
+            ChannelOriginAction.UNLINK_ALL_ACCESSORIES,
+            controller_sym_key=controller_sym_key,
+            controller_command_count=controller_command_count,
+        )
+    else:
+        assert msg_type == "LINK"
+        if accessory_sym_key is None or accessory_command_count is None:
+            raise ValueError(
+                u"Expected non-null accessory symmetric key and command count!"
+            )
+
+        return protocol.FactoryFullMessage.passthrough_channel_origin_command(
+            ChannelOriginAction.LINK_ACCESSORY_MODE_3,
+            controller_sym_key=controller_sym_key,
+            controller_command_count=controller_command_count,
+            accessory_sym_key=accessory_sym_key,
+            accessory_command_count=accessory_command_count,
+        )
 
 
 if __name__ == "__main__":
 
     def check_message_type(message_type):
-        if not isinstance(message_type, str) or str(message_type) not in VALID_MESSAGE_TYPES:
+        VALID_MESSAGE_TYPES_ALL = VALID_NXK_MESSAGE_TYPES + VALID_NXC_MESSAGE_TYPES
+        if (
+            not isinstance(message_type, str)
+            or str(message_type) not in VALID_MESSAGE_TYPES_ALL
+        ):
             raise argparse.ArgumentTypeError(
-                "'{}' is not in {}".format(message_type, VALID_MESSAGE_TYPES)
+                u"'{}' is not in {}".format(message_type, VALID_MESSAGE_TYPES_ALL)
             )
         return str(message_type)
 
@@ -40,22 +90,25 @@ if __name__ == "__main__":
             int(secret_key, 16)
         except ValueError:
             raise argparse.ArgumentTypeError(
-                "'{}' contains characters that are not valid hexadecimal values (a-f, 0-9)".format(
-                    secret_key
-                )
+                u"'{}' contains characters that are not valid hexadecimal values "
+                "(a-f, 0-9)".format(secret_key)
             )
 
         if len(secret_key) != 32:
             raise argparse.ArgumentTypeError(
-                "'{}' is not a 16-byte secret key (must be 32 hex characters)".format(secret_key)
+                u"'{}' is not a 16-byte secret key (must be 32 hex characters)".format(
+                    secret_key
+                )
             )
 
         decode_hex = codecs.getdecoder("hex_codec")
         return decode_hex(secret_key)[0]
 
     argparser = argparse.ArgumentParser(
-        description="Generate credit keycodes for Nexus Keycode 'full' protocol.",
-        epilog="python generate_full_keycode.py -t ADD -i 0 -k abcdef0011223344556677889900ffee -hr 30",
+        description="Generate credit or Channel keycodes for Nexus Keycode 'full' protocol.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="python generate_full_keycode.py -t ADD -i 0 -k abcdef0011223344556677889900ffee -hr 30\n"
+        "python generate_full_keycode.py -t LINK -ck abcdef0011223344556677889900ffee -cc 15 -ak aabbccddeeff11223344556677889900 -ac 3",
     )
 
     # Note: 'UNLOCK' is implemented as a special case of "SET", but for the purposes of this tool they are considered separate 'types'.
@@ -64,38 +117,83 @@ if __name__ == "__main__":
         "--message_type",
         required=True,
         type=check_message_type,
-        help="Credit keycode type. Valid options are: 'SET', 'ADD', 'UNLOCK'",
+        help="Keycode type. Valid options are: 'SET', 'ADD', 'UNLOCK', 'LINK', and 'UNLINK'",
     )
     argparser.add_argument(
         "-i",
         "--message_id",
-        required=True,
+        required=False,
         type=int,
         help="Keycode Message ID (e.g. 0, 1, 2, 3...)",
     )
     argparser.add_argument(
         "-k",
         "--secret_key",
-        required=True,
+        required=False,
         type=check_secret_key,
-        help="Hex-encoded 16-byte secret key, 32 characters long (e.g. 'abcdef0011223344556677889900ffee'",
+        help="Hex-encoded 16-byte symmetric key for Nexus Keycode, 32 characters long (e.g. 'abcdef0011223344556677889900ffee')",
     )
     argparser.add_argument(
-        "-hr", "--hours", required=True, type=int, help="Hours of credit. Ignored for 'UNLOCK'"
+        "-hr", "--hours", required=False, type=int, help="Hours of credit."
+    )
+    argparser.add_argument(
+        "-ck",
+        "--controller_key",
+        required=False,
+        type=check_secret_key,
+        help="Hex-encoded 16-byte Nexus Channel Controller symmetric key, 32 characters long (e.g. 'abcdef0011223344556677889900ffee')",
+    )
+    argparser.add_argument(
+        "-cc",
+        "--controller_count",
+        required=False,
+        type=int,
+        help="Nexus Channel Controller Command Count",
+    )
+    argparser.add_argument(
+        "-ak",
+        "--accessory_key",
+        required=False,
+        type=check_secret_key,
+        help="Hex-encoded 16-byte Nexus Channel Accessory symmetric key, 32 characters long (e.g. 'abcdef0011223344556677889900ffee')",
+    )
+    argparser.add_argument(
+        "-ac",
+        "--accessory_count",
+        required=False,
+        type=int,
+        help="Nexus Channel Accessory Command Count",
     )
 
-    # message_type, message_id, secret_key, days
     args = argparser.parse_args()
 
     msg_type = args.message_type
-    msg_id = args.message_id
-    key = args.secret_key
-    hours = args.hours
+    if msg_type in VALID_NXK_MESSAGE_TYPES:
+        msg_id = args.message_id
+        key = args.secret_key
+        hours = args.hours
+        msg = create_full_credit_message(msg_id, msg_type, key, hours)
 
-    msg = create_full_credit_message(msg_id, msg_type, key, hours)
-
-    print(
-        ("{}\n" "Message Type={}\n" "Message ID={}\n" "Message Hours={}\n").format(
-            msg.to_keycode(), msg_type, msg_id, hours
+        print(
+            (u"{}\n" "Message Type={}\n" "Message ID={}\n" "Message Hours={}\n").format(
+                msg.to_keycode(), msg_type, msg_id, hours
+            )
         )
-    )
+    else:
+        controller_key = args.controller_key
+        controller_count = args.controller_count
+        accessory_key = args.accessory_key
+        accessory_count = args.accessory_count
+
+        msg = create_full_channel_message(
+            msg_type, controller_key, controller_count, accessory_key, accessory_count
+        )
+
+        print(
+            (
+                u"{}\n"
+                "Message Type={}\n"
+                "Controller Count={}\n"
+                "Accessory Count={}\n"
+            ).format(msg.to_keycode(), msg_type, controller_count, accessory_count)
+        )

--- a/nexus_keycode/tools/qa/nexus_channel_integration_test_keycode_generator.py
+++ b/nexus_keycode/tools/qa/nexus_channel_integration_test_keycode_generator.py
@@ -1,0 +1,196 @@
+"""
+Generates keycodes for Nexus Channel integration test plan v1.0.0:
+https://docs.google.com/spreadsheets/d/16Xqwv0GToPna8NplMlhTdjdKZ40POz6arU9yW4_S_Xo/edit
+"""
+
+import csv
+import datetime
+
+from nexus_keycode.tools.generate_full_keycode import (
+    VALID_NXC_MESSAGE_TYPES,
+    VALID_NXK_MESSAGE_TYPES,
+    create_full_channel_message,
+    create_full_credit_message,
+)
+
+# device definitions; before running, update this section!
+# WARNING: assumes that Nexus Keycode and Channel secret keys are identical!
+NXC_CONTROLLER_A = dict(
+    nx_device_id=243456100, nxk_nxc_sym_key="\xaa" * 16, nxk_count=30, nxc_count=30
+)
+NXC_CONTROLLER_B = dict(
+    nx_device_id=243456209, nxk_nxc_sym_key="\xbb" * 16, nxk_count=30, nxc_count=30
+)
+NXC_ACCESSORY_A = dict(
+    nx_device_id=243458007, nxk_nxc_sym_key="\xcc" * 16, nxk_count=30, nxc_count=30
+)
+NXC_ACCESSORY_B = dict(
+    nx_device_id=243457900, nxk_nxc_sym_key="\xdd" * 16, nxk_count=30, nxc_count=30
+)
+
+# test definition according to the linked test plan document above
+TEST_STEPS = [
+    dict(step_number=2, device=NXC_CONTROLLER_A, keycode_type="UNLINK"),
+    dict(step_number=2, device=NXC_CONTROLLER_B, keycode_type="UNLINK"),
+    dict(step_number=3, device=NXC_CONTROLLER_A, keycode_type="SET", hours=0),
+    dict(step_number=3, device=NXC_CONTROLLER_B, keycode_type="SET", hours=0),
+    dict(step_number=7, device=NXC_CONTROLLER_A, keycode_type="ADD", hours=24),
+    dict(
+        step_number=8,
+        device=NXC_CONTROLLER_A,
+        keycode_type="LINK",
+        nxc_accessory=NXC_ACCESSORY_A,
+    ),
+    dict(
+        step_number=9,
+        device=NXC_CONTROLLER_A,
+        keycode_type="LINK",
+        nxc_accessory=NXC_ACCESSORY_B,
+    ),
+    dict(step_number=12, device=NXC_CONTROLLER_A, keycode_type="UNLOCK"),
+    dict(step_number=16, device=NXC_CONTROLLER_A, keycode_type="SET", hours=0),
+    dict(
+        step_number=17,
+        device=NXC_CONTROLLER_A,
+        keycode_type="LINK",
+        nxc_accessory=NXC_ACCESSORY_A,
+    ),
+    dict(step_number=18, device=NXC_CONTROLLER_A, keycode_type="ADD", hours=24),
+    dict(
+        step_number=21,
+        device=NXC_CONTROLLER_B,
+        keycode_type="LINK",
+        nxc_accessory=NXC_ACCESSORY_A,
+    ),
+    dict(
+        step_number=23,
+        device=NXC_CONTROLLER_B,
+        keycode_type="LINK",
+        nxc_accessory=NXC_ACCESSORY_B,
+    ),
+    dict(step_number=25, device=NXC_CONTROLLER_B, keycode_type="ADD", hours=24),
+]
+
+
+def create_keycodes(steps):
+    """Consume a list of dicts, each one describing a test step
+    that requires a keycode to be generated. Each dict should
+    include `step_number`, `device`, `keycode_type`, and any other
+    kwargs required to generate the token described in the step.
+
+    Return a list of dicts including the keycode as well as state
+    at the time of generating it, suitable for output or analysis."""
+    keycodes = list()
+    for step in steps:
+        # common message-generation parameters
+        keycode_type = step["keycode_type"]
+        key = step["device"]["nxk_nxc_sym_key"]
+
+        # begin to populate output dict
+        keycode_data = dict(
+            step_number=step["step_number"],
+            nexus_id=step["device"]["nx_device_id"],
+            secret_key=step["device"]["nxk_nxc_sym_key"],
+        )
+
+        # generate keycode
+        message = None
+        if keycode_type in VALID_NXK_MESSAGE_TYPES:
+            # activation / Nexus Keycode message
+            msg_args = dict(
+                msg_id=step["device"]["nxk_count"],
+                hours=step.get("hours", None),
+                secret_key=key,
+            )
+
+            message = create_full_credit_message(msg_type=keycode_type, **msg_args)
+
+            # increment NXK count
+            step["device"]["nxk_count"] = step["device"]["nxk_count"] + 1
+
+            # update output dict
+            keycode_data.update(msg_args)
+        elif keycode_type in VALID_NXC_MESSAGE_TYPES:
+            # origin command / Nexus Channel message
+            msg_args = dict(controller_command_count=step["device"]["nxc_count"])
+
+            # update msg_args with accessory data for link command
+            if keycode_type == "LINK":
+                accessory = step["nxc_accessory"]
+                msg_args.update(
+                    dict(
+                        accessory_command_count=accessory["nxc_count"],
+                        accessory_sym_key=accessory["nxk_nxc_sym_key"],
+                    )
+                )
+
+                # update accessory NXC count and add to output dict
+                keycode_data.update(
+                    dict(
+                        accessory_nx_id=accessory["nx_device_id"],
+                        accessory_command_count=accessory["nxc_count"],
+                        controller_command_count=step["device"]["nxc_count"],
+                    )
+                )
+                accessory["nxc_count"] = accessory["nxc_count"] + 1
+
+            message = create_full_channel_message(
+                keycode_type, controller_sym_key=key, **msg_args
+            )
+            # increment NXC count
+            step["device"]["nxc_count"] = step["device"]["nxc_count"] + 1
+
+            # update output dict
+            keycode_data.update(msg_args)
+        else:
+            raise ValueError(u"unexpected keycode_type in TEST_STEPS")
+
+        assert message
+
+        keycode_data.update(
+            dict(keycode_type=keycode_type, keycode=message.to_keycode())
+        )
+        keycodes.append(keycode_data)
+
+    return keycodes
+
+
+def print_keycodes(keycodes):
+    # print ordered headers to CSV outfile
+    now_utc_str = datetime.datetime.utcnow().strftime(u"%m%d%Y_%Hh%Mm%Ss")
+    out_filename = now_utc_str + u"_UTC_nxc_integration_test_v1-0-0_keycodes.csv"
+    with open(u"{}".format(out_filename), "w") as outfile:
+        writer = csv.DictWriter(
+            outfile,
+            fieldnames=[
+                "step_number",
+                "controller_nx_id",
+                "keycode_type",
+                "accessory_nx_id",
+                "keycode",
+                "controller_command_count",
+                "accessory_command_count",
+            ],
+        )
+        writer.writeheader()
+
+        for keycode in keycodes:
+            writer.writerow(
+                {
+                    "step_number": keycode["step_number"],
+                    "controller_nx_id": keycode["nexus_id"],
+                    "keycode_type": keycode["keycode_type"],
+                    "accessory_nx_id": keycode.get("accessory_nx_id", None),
+                    "keycode": keycode["keycode"],
+                    "controller_command_count": keycode.get(
+                        "controller_command_count", None
+                    ),
+                    "accessory_command_count": keycode.get(
+                        "accessory_command_count", None
+                    ),
+                }
+            )
+
+
+if __name__ == "__main__":
+    print_keycodes(create_keycodes(TEST_STEPS))

--- a/nexus_keycode/tools/qa/nexus_channel_integration_test_keycode_generator.py
+++ b/nexus_keycode/tools/qa/nexus_channel_integration_test_keycode_generator.py
@@ -1,6 +1,12 @@
 """
 Generates keycodes for Nexus Channel integration test plan v1.0.0:
 https://docs.google.com/spreadsheets/d/16Xqwv0GToPna8NplMlhTdjdKZ40POz6arU9yW4_S_Xo/edit
+
+To use,
+
+1. update data for devices under test in DEVICE DATA DEFINITION section below
+2. from this directory, `python nexus_channel_integration_test_keycode_generator.py`
+3. open the CSV that was generated
 """
 
 import csv
@@ -13,7 +19,7 @@ from nexus_keycode.tools.generate_full_keycode import (
     create_full_credit_message,
 )
 
-# device definitions; before running, update this section!
+# DEVICE DATA DEFINITION; before running, update this section!
 # WARNING: assumes that Nexus Keycode and Channel secret keys are identical!
 NXC_CONTROLLER_A = dict(
     nx_device_id=243456100, nxk_nxc_sym_key="\xaa" * 16, nxk_count=30, nxc_count=30

--- a/nexus_keycode/tools/qa/nexus_keycode_integration_test_keycode_generator.py
+++ b/nexus_keycode/tools/qa/nexus_keycode_integration_test_keycode_generator.py
@@ -1,6 +1,12 @@
 """
 Generates keycodes for Nexus Keycode integration test plan v1.4.0:
 https://docs.google.com/spreadsheets/d/1gx3SrzXoCtfBLMxT6rKwwDRiCZt9yCa7SIYjoyuHug8/edit#gid=674470677
+
+To use,
+
+1. update data for devices under test in DEVICE DATA DEFINITION section below
+2. from this directory, `python nexus_keycode_integration_test_keycode_generator.py`
+3. open the CSV that was generated
 """
 
 import csv
@@ -8,7 +14,7 @@ import datetime
 
 from nexus_keycode.tools.generate_full_keycode import create_full_credit_message
 
-# device definitions; before running, update this section!
+# DEVICE DATA DEFINITION; before running, update this section!
 NX_KEYCODE_TEST_DEVICE = dict(
     nx_device_id=123456789, sym_key="\xaa" * 16, message_id=30
 )

--- a/nexus_keycode/tools/qa/nexus_keycode_integration_test_keycode_generator.py
+++ b/nexus_keycode/tools/qa/nexus_keycode_integration_test_keycode_generator.py
@@ -1,0 +1,99 @@
+"""
+Generates keycodes for Nexus Keycode integration test plan v1.4.0:
+https://docs.google.com/spreadsheets/d/1gx3SrzXoCtfBLMxT6rKwwDRiCZt9yCa7SIYjoyuHug8/edit#gid=674470677
+"""
+
+import csv
+import datetime
+
+from nexus_keycode.tools.generate_full_keycode import create_full_credit_message
+
+# device definitions; before running, update this section!
+NX_KEYCODE_TEST_DEVICE = dict(
+    nx_device_id=123456789, sym_key="\xaa" * 16, message_id=30
+)
+
+# test definition according to the linked test plan document above
+TEST_STEPS = [
+    dict(step_number=1.1, keycode_type="ADD", hours=1),
+    dict(step_number=1.2, keycode_type="ADD", hours=168),
+    dict(step_number=1.3, keycode_type="UNLOCK"),
+    dict(step_number=1.4, keycode_type="SET", hours=0),
+    dict(step_number=2.1, keycode_type="ADD", hours=240),
+    dict(step_number=3.1, keycode_type="ADD", hours=48),
+]
+
+
+def create_keycodes(steps):
+    """Consume a list of dicts, each one describing a test step
+    that requires a keycode to be generated. Each dict should
+    include `step_number`, `keycode_type`, and any other
+    kwargs required to generate the keycode described in the step.
+
+    Return a list of dicts including the keycode as well as state
+    at the time of generating it, suitable for output or analysis."""
+    keycodes = list()
+    for step in steps:
+        # begin to populate output dict
+        keycode_data = dict(
+            step_number=step["step_number"],
+            nexus_id=NX_KEYCODE_TEST_DEVICE["nx_device_id"],
+        )
+
+        # generate keycode
+        message = None
+        msg_args = dict(
+            msg_id=NX_KEYCODE_TEST_DEVICE["message_id"],
+            msg_type=step["keycode_type"],
+            secret_key=NX_KEYCODE_TEST_DEVICE["sym_key"],
+            hours=step.get("hours", None),
+        )
+
+        message = create_full_credit_message(**msg_args)
+        assert message
+
+        # increment message ID
+        NX_KEYCODE_TEST_DEVICE["message_id"] = NX_KEYCODE_TEST_DEVICE["message_id"] + 1
+
+        # update output dict
+        keycode_data.update(msg_args)
+        keycode_data.update(dict(keycode=message.to_keycode()))
+
+        keycodes.append(keycode_data)
+
+    return keycodes
+
+
+def print_keycodes(keycodes):
+    # print ordered headers to CSV outfile
+    now_utc_str = datetime.datetime.utcnow().strftime(u"%m%d%Y_%Hh%Mm%Ss")
+    out_filename = now_utc_str + u"_UTC_nxk_integration_test_v1-4-0_keycodes.csv"
+    with open(u"{}".format(out_filename), "w") as outfile:
+        writer = csv.DictWriter(
+            outfile,
+            fieldnames=[
+                "step_number",
+                "nexus_id",
+                "keycode_type",
+                "message_id",
+                "hours",
+                "keycode",
+            ],
+        )
+        writer.writeheader()
+
+        for keycode in keycodes:
+            writer.writerow(
+                {
+                    "step_number": keycode["step_number"],
+                    "nexus_id": keycode["nexus_id"],
+                    "keycode_type": keycode["msg_type"],
+                    "message_id": keycode["msg_id"],
+                    "hours": keycode["hours"],
+                    "keycode": keycode["keycode"],
+                }
+            )
+
+
+if __name__ == "__main__":
+    print_keycodes(create_keycodes(TEST_STEPS))


### PR DESCRIPTION
## Contribution Guideline Acceptance

- [x] I have read and understand the [Individual Contributors License Agreement](CONTRIBUTING.md).
- [x] I accept the [Individual Contributors License Agreement](CONTRIBUTING.md) on the entire contents of this pull request.

## Proposed changes

These scripts (`nexus_keycode/tools/qa/nexus_channel_integration_test_keycode_generator.py` and `nexus_keycode/tools/qa/nexus_keycode_integration_test_keycode_generator.py`) replace the need for a manufacturing partner to generate keycodes to follow QA signoff test plans on the platform. With knowledge of the device state (secret key and message ID / command count) they can generate all the keycodes locally. They can then use the keycodes with the QA signoff test plan.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Attribution

This PR template derived from:
https://github.com/skcript/PR-Template

Original template is:

Copyright (c) 2017 Skcript

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.
